### PR TITLE
Update installation instructions to use conda and github

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -15,9 +15,9 @@ Welcome to the Pydecorate documentation!
 Pydecorate is a package for decorating PIL images with logos, texts, and color
 scales.
 
-The source code of the package can be found at google codes, googlecode_
+The source code of the package can be found at on GitHub_.
 
-.. _googlecode: http://code.google.com/p/pydecorate/
+.. _GitHub: https://github.com/pytroll/pydecorate
 
 Contents
 +++++++++

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -6,49 +6,24 @@
    :suffix: .
 
 Installation
-------------
+============
 
-You can download the pydecorate source code from googlecodes,::
+Pydecorate can be installed in a conda environment by using the conda-forge
+channel::
 
-  $> git clone https://code.google.com/p/pydecorate/
+    conda install -c conda-forge pydecorate
 
-and then run::
+Or using pip::
 
-  $> python setup.py install
+    pip install pydecorate
 
+Development Installation
+------------------------
 
+To install from source, clone the git repository::
 
-Transparency and antialiasing using AGG
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The default plotting mode of pydecorate uses PIL for rendering. 
-However, PIL does not support antialiasing and opacity. 
-The AGG engine can be used for making high quality images using the aggdraw_ module.
+    git clone https://github.com/pytroll/pydecorate.git
 
-First make sure you have libfreetype and it's development files installed - on debian based systems you might do:
+Then use pip to install the package in development mode::
 
-.. code-block:: bash
-
-    $> sudo apt-get install libfreetype6 libfreetype6-dev
-
-First install the aggdraw_ module. Please not that aggdraw_ is getting old and may have the following problems in building.
-pip and easy_install may not solve these problems, so we recommend manual install.
-
-With the current source of aggdraw_, it is necessary to point the build at the root of
-Freetype install. To do this you must edit the aggdraw setup.py file, usually setting *FREETYPE_ROOT = "/usr"*
-This is necessary for aggdraw to render text.
-
-If the building of aggdraw fails with:
-
-.. code-block:: bash
-
-    agg_array.h:523: error: cast from ‘agg::int8u*’ to ‘unsigned int’ loses precision
-    
-Try:
-
-.. code-block:: bash
-
-    export CFLAGS="-fpermissive"
-    
-before building.
-
-
+    pip install -e .


### PR DESCRIPTION
The installation instructions all used google code which isn't used any more. They also had a lot of instructions for installing aggdraw and other dependencies which shouldn't be needed any more.