### PR TITLE
Fix font loading when adding scale (colorbar)

### DIFF
--- a/pydecorate/decorator_base.py
+++ b/pydecorate/decorator_base.py
@@ -433,6 +433,9 @@ class DecoratorBase(object):
         # draw object
         draw = self._get_canvas(self.image)
 
+        # check for font object
+        self._get_current_font()
+
         # draw base
         px = (self.style['propagation'][0] +
               self.style['newline_propagation'][0])


### PR DESCRIPTION
Add a check for font object in __add_scale_ as suggested by @djhoese 

Now it should be possible to specify a font, fontsize and color for scale values/labels and colorbar title, e.g.: 

`'font': '/usr/share/fonts/truetype/dejavu/DejaVuSerif.ttf', 'font_size': 20,'line': 'white' `