### PR TITLE
Adding Power support(ppc64le) with continuous integration/testing the project stays architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,32 @@ matrix:
   - env: PYTHON_VERSION=3.8
     os: osx
     language: generic
+  - env: PYTHON_VERSION=3.8
+    os: linux
+    language: generic
+    arch: ppc64le
+  - env: PYTHON_VERSION=3.7
+    os: linux
+    arch: ppc64le
+    language: generic
 install:
-- git clone --depth 1 git://github.com/astropy/ci-helpers.git
-- source ci-helpers/travis/setup_conda.sh
-- pip install --no-deps -e .
+ - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then 
+       wget https://repo.anaconda.com/pkgs/misc/conda-execs/conda-4.7.11-linux-ppc64le.exe -O conda.exe;
+       chmod +x conda.exe;
+       export CONDA_ALWAYS_YES=1;
+       ./conda.exe create -p $HOME/miniconda python=$TRAVIS_PYTHON_VERSION conda pytest pytest-cov ;
+       export PATH="$HOME/miniconda/bin:$PATH";
+       hash -r;
+       pip install Pillow;
+       pip install numpy;
+       pip install trollimage;
+       pip install aggdraw;
+       pip install --no-deps -e .;
+   else
+       git clone --depth 1 git://github.com/astropy/ci-helpers.git;
+       source ci-helpers/travis/setup_conda.sh;
+       pip install --no-deps -e .;
+   fi
 script:
 - pytest --cov=pydecorate test.py
 after_success:


### PR DESCRIPTION
I am part of IBM team and working on porting power arch to packages as continuous integration & testing.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing,    We typically build applications for customers and ISVs, and while we don't use this package directly,
we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model, For more info tag @gerrith3.

Pls verify and merge