### PR TITLE
Add missing setuptools dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     packages=["pydecorate"],
     include_package_data=True,
     package_data={"pydecorate": ["fonts/*.ttf"]},
-    install_requires=["pillow", "aggdraw", "numpy"],
+    install_requires=["pillow", "aggdraw", "numpy", "setuptools"],
     setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     scripts=[],
     data_files=[],


### PR DESCRIPTION
We use pkg_resources on import to find in-package resources like fonts. This is rarely not installed in a users environment, but we should be explicit. It was causing failures on conda-forge.