### PR TITLE
Fix colorbar orientation to always be min->max

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
-    needs: [lint]
     strategy:
       fail-fast: true
       matrix:
@@ -57,11 +56,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
-
-#      - name: Set up Python
-#        uses: actions/setup-python@v4
-#        with:
-#          python-version: "${{ matrix.python-version }}"
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,27 +8,6 @@ concurrency:
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: lint and style checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install flake8 flake8-docstrings flake8-debugger flake8-bugbear pytest
-      - name: Install Pydecorate
-        run: |
-          pip install -e .
-      - name: Run linting
-        run: |
-          flake8 pydecorate/
-
   website:
     name: build website
     runs-on: ubuntu-latest
@@ -41,7 +20,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install Pydecorate
         shell: bash -l {0}
@@ -62,10 +41,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.10"]
+        python-version: ["3.9", "3.11"]
         experimental: [false]
         include:
-          - python-version: "3.10"
+          - python-version: "3.11"
             os: "ubuntu-latest"
             experimental: true
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^$'
 fail_fast: false
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.12.0
     hooks:
       - id: black
         language_version: python3
@@ -37,7 +37,7 @@ repos:
           - types-PyYAML
           - types-requests
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         language_version: python3

--- a/pydecorate/decorator_base.py
+++ b/pydecorate/decorator_base.py
@@ -757,7 +757,7 @@ def _create_colorbar_image(
 
     if is_vertical:
         linedata = np.ones((scale_width, 1)) * np.arange(
-            minval, maxval, float(maxval - minval) / scale_height
+            maxval, minval, float(minval - maxval) / scale_height
         )
         linedata = linedata.transpose()
     else:

--- a/pydecorate/decorator_base.py
+++ b/pydecorate/decorator_base.py
@@ -431,9 +431,16 @@ class DecoratorBase(object):
 
         # generate color scale image obj inset by margin size mx my,
         # TODO: THIS PART TO BE INGESTED INTO A COLORMAP FUNCTION
-        minval, maxval = colormap.values[0], colormap.values[-1]
+        first_cmap_value, last_cmap_value = colormap.values[0], colormap.values[-1]
+        min_cmap_value = min(first_cmap_value, last_cmap_value)
+        max_cmap_value = max(first_cmap_value, last_cmap_value)
         scale = _create_colorbar_image(
-            colormap, minval, maxval, scale_height, scale_width, is_vertical
+            colormap,
+            min_cmap_value,
+            max_cmap_value,
+            scale_height,
+            scale_width,
+            is_vertical,
         )
         ###########################################################
 
@@ -448,8 +455,8 @@ class DecoratorBase(object):
         draw = self._get_canvas(self.image)
         self._draw_colorbar_ticks(
             draw,
-            minval,
-            maxval,
+            min_cmap_value,
+            max_cmap_value,
             is_vertical,
             scale_width,
             scale_height,
@@ -748,7 +755,7 @@ class DecoratorBase(object):
 
 
 def _create_colorbar_image(
-    colormap, minval, maxval, scale_height, scale_width, is_vertical
+    colormap, min_cmap_value, max_cmap_value, scale_height, scale_width, is_vertical
 ):
     if TImage is None:
         raise ImportError(
@@ -756,13 +763,18 @@ def _create_colorbar_image(
         )
 
     if is_vertical:
+        # Image arrays have row 0 being the top of the image so we must flip all calculations
         linedata = np.ones((scale_width, 1)) * np.arange(
-            maxval, minval, float(minval - maxval) / scale_height
+            max_cmap_value,
+            min_cmap_value,
+            float(min_cmap_value - max_cmap_value) / scale_height,
         )
         linedata = linedata.transpose()
     else:
         linedata = np.ones((scale_height, 1)) * np.arange(
-            minval, maxval, float(maxval - minval) / scale_width
+            min_cmap_value,
+            max_cmap_value,
+            float(max_cmap_value - min_cmap_value) / scale_width,
         )
 
     timg = TImage(linedata, mode="L")

--- a/pydecorate/decorator_base.py
+++ b/pydecorate/decorator_base.py
@@ -763,18 +763,20 @@ def _create_colorbar_image(
         )
 
     if is_vertical:
-        # Image arrays have row 0 being the top of the image so we must flip all calculations
-        linedata = np.ones((scale_width, 1)) * np.arange(
+        # Image arrays have row 0 being the top of the image, so we must flip all calculations
+        linedata = np.ones((scale_width, 1)) * np.linspace(
             max_cmap_value,
             min_cmap_value,
-            float(min_cmap_value - max_cmap_value) / scale_height,
+            scale_height,
+            endpoint=True,
         )
         linedata = linedata.transpose()
     else:
-        linedata = np.ones((scale_height, 1)) * np.arange(
+        linedata = np.ones((scale_height, 1)) * np.linspace(
             min_cmap_value,
             max_cmap_value,
-            float(max_cmap_value - min_cmap_value) / scale_width,
+            scale_width,
+            endpoint=True,
         )
 
     timg = TImage(linedata, mode="L")

--- a/pydecorate/decorator_base.py
+++ b/pydecorate/decorator_base.py
@@ -768,7 +768,7 @@ def _create_colorbar_image(
             max_cmap_value,
             min_cmap_value,
             scale_height,
-            endpoint=True,
+            endpoint=False,
         )
         linedata = linedata.transpose()
     else:
@@ -776,7 +776,7 @@ def _create_colorbar_image(
             min_cmap_value,
             max_cmap_value,
             scale_width,
-            endpoint=True,
+            endpoint=False,
         )
 
     timg = TImage(linedata, mode="L")

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     setup_requires=["setuptools_scm", "setuptools_scm_git_archive"],
     scripts=[],
     data_files=[],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     extras_require={
         "tests": tests_require,
         "docs": ["sphinx", "sphinx_rtd_theme", "sphinxcontrib-apidoc", "trollimage"],


### PR DESCRIPTION
A user of one of my projects noticed that the colors for vertical colorbars (scales) had the colors flipped from what they should be. As far as I can tell this has always been like this. Additionally, the colormap was always assumed to have increasing values, but in recent versions of trollimage it is possible to have values in reverse order (flipped values versus flipped colors). This produces colorbars that don't follow what I think most people would expect which is for the colorbar to go from the minimum value to the maximum value. In the horizontal orientation this means minimum value on the left, maximum on the right. For vertical orientation this means minimum value on the bottom, maximum on the top. This PR fixes all of this.

![montage](https://user-images.githubusercontent.com/1828519/215807083-8c89de6e-9701-447e-b0ab-49ab3c804fbc.png)
