### PR TITLE
Fix .git_archival.txt not matching setuptools_scm suggestions

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$


### PR DESCRIPTION
I apparently didn't deprecate the setuptools_scm_git_archive tool properly (see README):

https://github.com/Changaco/setuptools_scm_git_archive